### PR TITLE
WP CLI Support

### DIFF
--- a/cloud-search-wp-cli.php
+++ b/cloud-search-wp-cli.php
@@ -120,8 +120,6 @@ class Cloud_Search_WP_CLI extends WP_CLI_Command {
 		global $wpdb;
 
 		$defaults = array(
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
 			'write_to_file' => 'no',
 		);
 
@@ -165,7 +163,7 @@ class Cloud_Search_WP_CLI extends WP_CLI_Command {
 			// Retrieve allowed post statutes to manage
 			$allowed_statuses = apply_filters( 'acs_post_transition_allowed_statuses', array( 'publish' ), $post );
 
-			if ( in_array( $new_status, $allowed_statuses ) && ( ! isset( $excluded ) || empty( $excluded ) || $excluded != 1 ) ) {
+			if ( in_array( $post->post_status, $allowed_statuses ) && ( ! isset( $excluded ) || empty( $excluded ) || $excluded != 1 ) ) {
 				$this->line( 'SYNCING: (' . $post->ID . ') ' . get_the_title( $post->ID ) );
 
 				// If post status is "allowed" and is not excluded, add or update it to index

--- a/cloud-search-wp-cli.php
+++ b/cloud-search-wp-cli.php
@@ -161,6 +161,7 @@ class Cloud_Search_WP_CLI extends WP_CLI_Command {
 		$query = new WP_Query( $query_args );
 		$total_pages = $query->max_num_pages;
 
+		// Iterate through the full results by page/chunk
 		while ( $page <= $total_pages ) {
 			$query_args['paged'] = $page;
 
@@ -204,7 +205,7 @@ class Cloud_Search_WP_CLI extends WP_CLI_Command {
 			$page++;
 		}
 
-		$this->success( count( $documents ) . ' documents(s) synced!' );
+		$this->success( count( $query->found_posts ) . ' documents(s) synced!' );
 	}
 
 	/**

--- a/cloud-search-wp-cli.php
+++ b/cloud-search-wp-cli.php
@@ -97,11 +97,11 @@ class Cloud_Search_WP_CLI extends WP_CLI_Command {
 		// Run indexing action
 		try {
 			$result = acs_run_indexing();
-			$message = new ACS_Message( '<strong>Success</strong>: Run indexing started for %s fields', $result->get_data()[ 'fields_managed' ], ACS_Message::TYPE_INFO );
+			$message = new ACS_Message( 'Run indexing started for %s fields', $result->get_data()[ 'fields_managed' ], ACS_Message::TYPE_INFO );
 
 			$this->success( $message->get_text() );
 		} catch ( Exception $e ) {
-			$message = new ACS_Message( '<strong>Error</strong>: %s', $e->getMessage(), ACS_Message::TYPE_ERROR );
+			$message = new ACS_Message( '%s', $e->getMessage(), ACS_Message::TYPE_ERROR );
 
 			$this->error( $message->get_text() );
 		}

--- a/cloud-search-wp-cli.php
+++ b/cloud-search-wp-cli.php
@@ -1,0 +1,285 @@
+<?php
+/*
+Plugin Name: CloudSearch
+Description: CloudSearch is a flexible plugin that allows you to leverage the search index power of Amazon CloudSearch in your WordPress site.
+Author: Andrea Landonio
+Author URI: http://www.andrealandonio.it
+Text Domain: cloud-search
+Domain Path: /languages/
+Version: 2.5.0
+License: GPL v3
+
+CloudSearch
+Copyright (C) 2013-2019, Andrea Landonio - landonio.andrea@gmail.com
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Security check
+if ( ! defined( 'ABSPATH' ) ) die( 'Direct access to files not allowed' );
+
+if ( ! defined('WP_CLI') || ! WP_CLI ) {
+    return;
+}
+
+class Cloud_Search_WP_CLI extends WP_CLI_Command {
+	public $write_to_file = false;
+	public $file = false;
+    public $current_method;
+	public $current_command;
+
+    /**
+     * Create/Update index
+     *
+     * ## EXAMPLES
+     *
+     *     wp cloudsearch create_index
+     *
+     * @synopsis
+     */
+	public function create_index( ) {
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
+		$this->start_feedback( __FUNCTION__, $assoc_args );
+
+		try {
+			$result = acs_index_create();
+
+			if ( count( $result->get_data()[ 'fields_with_error' ] ) > 0 && $result->get_data()[ 'fields_managed' ] == 0) {
+				// Found only error fields
+				$message = new ACS_Message( 'Fields with errors: %s', implode( ACS::SEPARATOR, $result->get_data()[ 'fields_with_error' ] ), ACS_Message::TYPE_ERROR );
+
+				$this->error( $message->get_text() );
+			} elseif ( count( $result->get_data()[ 'fields_with_error' ] ) > 0 && $result->get_data()[ 'fields_managed' ] > 0) {
+				// Found error fields but one or more index fields created
+				$message = new ACS_Message( 'Some index fields created/updated correctly, but there are fields with errors: %s', implode( ACS::SEPARATOR, $result->get_data()[ 'fields_with_error' ] ), ACS_Message::TYPE_ERROR );
+
+				$this->error( $message->get_text() );
+			} elseif ( $result->get_data()[ 'fields_managed' ] == 0 ) {
+				// Schema already defined (no new index fields)
+				$message = new ACS_Message( 'No index fields created/updated, all index fields are already defined', '', ACS_Message::TYPE_INFO );
+
+				$this->success( $message->get_text() );
+			} else {
+				// Schema created
+				$message = new ACS_Message( '%s index fields created/updated', $result->get_data()[ 'fields_managed' ], ACS_Message::TYPE_INFO );
+
+				$this->success( $message->get_text() );
+			}
+		} catch ( Exception $e ) {
+			$message = new ACS_Message( '%s', $e->getMessage(), ACS_Message::TYPE_ERROR );
+
+			$this->error( $message->get_text() );
+		}
+	}
+
+    /**
+     * Run indexing
+     *
+     * ## EXAMPLES
+     *
+     *     wp cloudsearch run_indexing
+     *
+     * @synopsis
+     */
+	public function run_indexing() {
+		// Run indexing action
+		try {
+			$result = acs_run_indexing();
+			$message = new ACS_Message( '<strong>Success</strong>: Run indexing started for %s fields', $result->get_data()[ 'fields_managed' ], ACS_Message::TYPE_INFO );
+
+			$this->success( $message->get_text() );
+		} catch ( Exception $e ) {
+			$message = new ACS_Message( '<strong>Error</strong>: %s', $e->getMessage(), ACS_Message::TYPE_ERROR );
+
+			$this->error( $message->get_text() );
+		}
+	}
+
+    /**
+     * Sync documents by post_type and post_status
+     *
+     * ## EXAMPLES
+     *
+     *     wp cloudsearch sync_documents --write_to_file=yes
+     *
+     * @synopsis
+     */
+	public function sync_documents( $args, $assoc_args ) {
+		global $wpdb;
+
+		$defaults = array(
+			'post_type'     => 'post',
+			'post_status'   => 'publish',
+			'write_to_file' => 'no',
+		);
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
+		if ( 'yes' == $assoc_args['write_to_file'] ) {
+			$this->write_to_file = true;
+		}
+
+		$this->start_feedback( __FUNCTION__, $assoc_args );
+
+		// Get settings option
+		$settings = ACS::get_instance()->get_settings();
+
+		$acs_schema_types = $settings->acs_schema_types;
+		$acs_schema_types = $acs_schema_types ? explode( ACS::SEPARATOR, $acs_schema_types ) : array();
+
+		$get_posts_args = array(
+			'post_type'      => $acs_schema_types,
+			'post_status'    => array(
+				'publish',
+				'pending',
+				'draft',
+				'auto-draft',
+				'future',
+				'private',
+				'inherit',
+				'trash',
+			),
+			'orderby'        => 'date',
+			'sort'           => 'desc',
+			'posts_per_page' => -1
+		);
+
+		$documents = get_posts( $get_posts_args );
+
+		foreach ( $documents as $post ) {
+			// Read post exclusion field
+			$excluded = get_post_meta( $post->ID, ACS::EXCLUDE_FIELD, true );
+
+			// Retrieve allowed post statutes to manage
+			$allowed_statuses = apply_filters( 'acs_post_transition_allowed_statuses', array( 'publish' ), $post );
+
+			if ( in_array( $new_status, $allowed_statuses ) && ( ! isset( $excluded ) || empty( $excluded ) || $excluded != 1 ) ) {
+				$this->line( 'SYNCING: (' . $post->ID . ') ' . get_the_title( $post->ID ) );
+
+				// If post status is "allowed" and is not excluded, add or update it to index
+				try {
+	                acs_index_document( $post, true );
+				}
+				catch ( Exception $e ) {
+					$message = $e->getMessage();
+					$this->warning( $message->get_text() );
+				}
+			} else {
+				$this->line( 'DELETING: (' . $post->ID . ') ' . get_the_title( $post->ID ) );
+
+				// If post is not allowed or is excluded, delete it from index
+				try {
+					acs_delete_document( $post );
+				}
+				catch ( Exception $e ) {
+					$message = $e->getMessage();
+					$this->warning( $message->get_text() );
+
+				}
+			}
+		}
+
+		$this->success( count( $documents ) . ' documents(s) synced!' );
+	}
+
+	/**
+	 * Starts output and sets some class vars for use in logging
+	 *
+	 * @param string The name of the current function being run
+	 * @param array An array of the arguments passed to WP CLI for the current fucntion
+	 */
+	public function start_feedback( $function, $assoc_args ) {
+		$this->current_method = $function;
+		$this->current_command = 'wp go_ossein ' . $this->current_method;
+
+		foreach ( $assoc_args as $key => $value ) {
+			$this->current_command .= ' --' . $key . '=' . $value;
+		}
+
+		$this->line( 'Starting: ' . $this->current_command );
+	}
+
+	/**
+	 * Writes a line to output or a log file
+	 *
+	 * @param string Some text you want written
+	 */
+	public function line( $message ) {
+		if ( $this->write_to_file ) {
+			$this->open_file();
+			$this->output .= $message . "\n";
+			fwrite( $this->file, $message . "\n" );
+		} else {
+			WP_CLI::line( $message );
+		}
+	}
+
+	/**
+	 * Writes a warning line to output or a log file
+	 *
+	 * @param string Some text you want written
+	 */
+	public function warning( $message ) {
+		if ( $this->write_to_file ) {
+			$this->open_file();
+			$this->output .= 'Warning: ' . $message . "\n";
+			fwrite( $this->file, 'Warning: ' . $message . "\n" );
+		} else {
+			WP_CLI::warning( $message );
+		}
+	}
+
+	/**
+	 * Writes a success line to output or a log file
+	 *
+	 * @param string Some text you want written
+	 */
+	public function success( $message ) {
+		if ( $this->write_to_file ) {
+			$this->open_file();
+			$this->output .= 'Success: ' . $message . "\n";
+			fwrite( $this->file, 'Success: ' . $message . "\n" );
+			fclose( $this->file );
+		} else {
+			WP_CLI::success( $message );
+		}
+	}
+
+	/**
+	 * Writes an error line to output or a log file AND stops the script
+	 */
+	public function error( $message ) {
+		if ( $this->write_to_file ) {
+			$this->open_file();
+			$this->output .= 'Error: ' . $message . "\n";
+			fwrite( $this->file, 'Error: ' . $message . "\n" );
+			fclose( $this->file );
+			die;
+		} else {
+			WP_CLI::error( $message );
+		}
+	}
+
+	/**
+	 * Opens a log file if needed
+	 */
+	public function open_file() {
+		if ( ! $this->file ) {
+			$this->file = fopen( ABSPATH . 'cloudsearch-wp-cli-' . str_replace( '_', '-', $this->current_method ) . '.txt', 'w+' );
+		}
+	}
+}
+
+WP_CLI::add_command( 'cloudsearch', 'Cloud_Search_WP_CLI' );

--- a/cloud-search.php
+++ b/cloud-search.php
@@ -43,6 +43,7 @@ require_once( 'cloud-search-utils.php' );
 require_once( 'cloud-search-hooks.php' );
 require_once( 'cloud-search-schema.php' );
 require_once( 'cloud-search-indexer.php' );
+require_once( 'cloud-search-wp-cli.php' );
 
 /**
  * Register activation hook


### PR DESCRIPTION
This adds some basic WP CLI commands.

```
wp cloudsearch create_index
wp cloudsearch run_indexing
wp cloudsearch sync_documents
```

The first two mirror the **Create/update index** and **Run indexing** buttons in the Manage admin panel.

The final one somewhat mirrors the **Sync all index documents** button but has a few changes:

1. It only does posts
2. It grabs all post statuses 
3. It runs the `acs_post_transition_allowed_statuses` so that posts that ordinarily wouldn't get indexed can be indexed
4. It runs `acs_delete_document` on any posts that fail the status or exclusion checks

I made it work this way for a few reasons but namely it allows you to make sure that your index of documents on AWS is actually fully synced AND cleaned up. This helps especially if someone has a few failed attempts to sync stuff up via the default Admin panel functionality. 

Additionally I'm pretty sure the default **Sync all index documents** is ignoring the filter hook.

Open to thoughts and critiques and any code review issues as always.

Also at this point I haven't fully tested this so don't feel the need to merge yet. Let me run some fully syncs tonight and over the next few days so I can confirm it's all behaving as I intended.